### PR TITLE
Fix event deletion to use TTL instead of informer deletion

### DIFF
--- a/pkg/kubernetes/handlers/event_handler.go
+++ b/pkg/kubernetes/handlers/event_handler.go
@@ -78,11 +78,10 @@ func (h *EventHandler) HandleCreate(ctx context.Context, obj interface{}, neo4jC
 }
 
 func (h *EventHandler) HandleDelete(ctx context.Context, obj interface{}, neo4jClient *neo4j.Client) error {
-	event, err := ConvertToTyped[*corev1.Event](obj)
-	if err != nil {
-		return fmt.Errorf("failed to convert event: %w", err)
-	}
-	return HandleResourceDelete(ctx, "Event", string(event.UID), neo4jClient)
+	// Do not delete events from Neo4j when Kubernetes deletes them
+	// Events should persist in Neo4j and only be cleaned up via TTL mechanism
+	// using PruneExpiredEvents function
+	return nil
 }
 
 // PruneExpiredEvents deletes Event nodes older than the given TTL (in days)


### PR DESCRIPTION
## Summary
- Prevent events from being deleted from Neo4j when Kubernetes deletes them
- Events now persist in Neo4j and are only cleaned up via TTL mechanism using PruneExpiredEvents function
- This ensures events are retained for the configured TTL period regardless of Kubernetes lifecycle

## Changes
- Modified `HandleDelete` method in `EventHandler` to return `nil` instead of calling `HandleResourceDelete`  
- Added descriptive comments explaining the TTL-based cleanup approach

## Test plan
- Build and deploy the updated code
- Verify that events are no longer deleted from Neo4j when Kubernetes deletes them
- Confirm that events are still cleaned up properly via the TTL mechanism during background cleanup cycles