### PR TITLE
Security: Enhance .env file protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,8 @@ build/
 
 # Configuration files with secrets
 *.env
-.env
+.env*
+**/.env*
 .env.local
 .env.production
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ We welcome contributions! Please:
 - **Secret Handling**: Secret data is never stored in Neo4j (metadata only)
 - **RBAC**: Follows least-privilege principle (read-only access)
 - **Neo4j Security**: Use secure connections and credentials for production
+- **Environment Files**: Never commit `.env` files with real credentials to version control. Use example files with placeholder values only.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Enhanced .gitignore patterns to comprehensively exclude all .env files from version control
- Added security documentation warning against committing .env files with real credentials
- Ensures better protection of sensitive configuration data

## Test plan

- [x] Verified .gitignore patterns exclude .env files in all subdirectories
- [x] Confirmed existing example .env files remain as documentation
- [x] Added clear security guidance in README

## Changes

### .gitignore
- Enhanced .env exclusion patterns with `.env*` and `**/.env*`
- Provides comprehensive protection for environment files

### README.md
- Added security note about proper .env file handling
- Emphasizes use of placeholder values in example files only